### PR TITLE
add PhishingCorpus dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add tools or resour
 * [Publicly available PCAP files](http://www.netresec.com/?page=PcapFiles)
 * [2007 TREC Public Spam Corpus](https://plg.uwaterloo.ca/~gvcormac/treccorpus07/)
 * [Drebin Android Malware Dataset](https://www.sec.cs.tu-bs.de/~danarp/drebin/)
+* [PhishingCorpus Datset](https://monkey.org/~jose/phishing/)
 
 ## [↑](#table-of-contents) Papers
 


### PR DESCRIPTION
PhishingCorpus is a set of mbox files from my personal archive showing over ten years of phishing attacks. The data set has been used in several academic publications and represents a unique data set of phishing lures. 