### PR TITLE
fix cylance Intro to AI book link, PDF gone

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ by Intellectual Analysis of System Journals (RUS)](http://cyberrus.com/wp-conten
 * [Machine Learning and Data Mining for Computer Security](https://www.amazon.com/Machine-Learning-Mining-Computer-Security/dp/184628029X)
 * [Network Anomaly Detection: A Machine Learning Perspective](https://www.amazon.com/Network-Anomaly-Detection-Learning-Perspective/dp/1466582081)
 * [Machine Learning and Security: Protecting Systems with Data and Algorithms](https://www.amazon.com/Machine-Learning-Security-Protecting-Algorithms/dp/1491979909)
-* [Introduction To Artificial Intelligence For Security Professionals](http://defense.ballastsecurity.net/static/IntroductionToArtificialIntelligenceForSecurityProfessionals_Cylance.pdf)
+* [Introduction To Artificial Intelligence For Security Professionals](https://www.amazon.com/Introduction-Artificial-Intelligence-Security-Professionals-ebook/dp/B07654CFFQ)
 * [Mastering Machine Learning for Penetration Testing](https://www.packtpub.com/networking-and-servers/mastering-machine-learning-penetration-testing)
 
 ## [↑](#table-of-contents) Talks


### PR DESCRIPTION
the PDF is gone, now point to the amazon link like other books 