### PR TITLE
Add Malware Families Catalog to Datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Please read [CONTRIBUTING](./CONTRIBUTING.md) if you wish to add tools or resour
 * [Probing / Port Scan - Dataset ](https://github.com/gubertoli/ProbingDataset)
 * [Aegean Wireless Intrusion Dataset (AWID)](http://icsdweb.aegean.gr/awid/)
 * [BODMAS PE Malware Dataset](https://whyisyoung.github.io/BODMAS/)
+* [Malware Families Catalog](https://jordanricky1604-ship-it.github.io/malware-families-catalog/) - Open catalog of 2,899 real-world malware families extracted from the EMBER 2018 benchmark, with mirrors on [Hugging Face](https://huggingface.co/datasets/Jordan123234/malware-families-catalog) and [Kaggle](https://www.kaggle.com/datasets/rickyjordan/malware-families-catalog).
 
 ## [↑](#table-of-contents) Papers
 


### PR DESCRIPTION
Adds the Malware Families Catalog — an open dataset of 2,899 real-world malware families derived from the EMBER 2018 benchmark, categorized for security teams, SOC analysts, and ML-for-cybersecurity research.

- Canonical: https://jordanricky1604-ship-it.github.io/malware-families-catalog/
- HuggingFace mirror: https://huggingface.co/datasets/Jordan123234/malware-families-catalog
- Kaggle mirror: https://www.kaggle.com/datasets/rickyjordan/malware-families-catalog
- License: Apache-2.0

Appended to the Datasets section after "BODMAS PE Malware Dataset" — complements the existing EMBER entry by providing a categorized family-level view of the same benchmark.